### PR TITLE
Fix reloading not working properly.

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -2,6 +2,11 @@
 
 package sdnotify
 
+
+func Reloading() error {
+	return nil
+}
+
 // SdNotify sends a specified string to the systemd notification socket.
 func SdNotify(state string) error {
 	// do nothing

--- a/notify_linux.go
+++ b/notify_linux.go
@@ -1,9 +1,21 @@
 package sdnotify
 
 import (
+	"fmt"
 	"net"
 	"os"
 )
+
+/*
+#include <time.h>
+static unsigned long long get_nsecs(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (unsigned long long)ts.tv_sec * 1000000000UL + ts.tv_nsec;
+}
+*/
+import "C"
 
 // SdNotify sends a specified string to the systemd notification socket.
 func SdNotify(state string) error {
@@ -20,4 +32,11 @@ func SdNotify(state string) error {
 
 	_, err = conn.Write([]byte(state))
 	return err
+}
+
+// Reloading sends RELOADING=1\nMONOTONIC_USEC=<monotonic_time> to the 
+// systemd notify socket.
+func Reloading() error {
+	return SdNotify(fmt.Sprintf("RELOADING=1\nMONOTONIC_USEC=%d",
+			C.get_nsecs() / 1000))
 }

--- a/util.go
+++ b/util.go
@@ -18,11 +18,6 @@ func Stopping() error {
 	return SdNotify("STOPPING=1")
 }
 
-// Reloading sends RELOADING=1 to the systemd notify socket.
-func Reloading() error {
-	return SdNotify("RELOADING=1")
-}
-
 // Errno sends ERRNO=? to the systemd notify socket.
 func Errno(errno int) error {
 	return SdNotify(fmt.Sprintf("ERRNO=%d", errno))


### PR DESCRIPTION
With an sd-notify service, systemd does not acknowledge the reloading and will timeout unless MONOTONIC_USEC is passed. From the systemd.service man page:

    When initiating the reload process the service is expected to reply
    with a notification message via sd_notify(3) that contains the
    "RELOADING=1" field in combination with "MONOTONIC_USEC=" set to
    the current monotonic time (i.e. CLOCK_MONOTONIC in
    clock_gettime(2)) in μs, formatted as decimal string. Once reloading
    is complete another notification message must be sent, containing
    "READY=1".

We call the clock_gettime function directly as go does not provide an access to the system monotonic clock.

This forces us to move the Reloading util to  notify_linux.